### PR TITLE
Add Webfinger

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -10,9 +10,21 @@ import (
 )
 
 var (
-	// Pool is the pool opened for the database
-	Pool *sql.DB
+	// pool is the pool opened for the database
+	pool *sql.DB
 )
+
+// GetPool is a safer interface for accessing the Pool
+func GetPool() *sql.DB {
+	if pool == nil {
+		panic("GetPool() was used before the data.pool was defined." +
+			" In other words, we can't connect to the database!" +
+			" If this is happening in a test, did you use SetupTestDB() and" +
+			" maybe ConnectToTestDB() in your func init()?")
+	}
+
+	return pool
+}
 
 // NewDB opens a standard DB
 func NewDB() (*sql.DB, error) {
@@ -31,9 +43,9 @@ func NewDB() (*sql.DB, error) {
 	return sql.Open("postgres", psqlInfo)
 }
 
-// RegisterTestDB is used to setup a transactional database.
+// SetupTestDB is used to setup a transactional database.
 // Use it inside of an `init` function in a test file.
-func RegisterTestDB() {
+func SetupTestDB() {
 	const (
 		host   = "localhost"
 		port   = 5432
@@ -54,17 +66,15 @@ func NewTestDB() (*sql.DB, error) {
 	return sql.Open("txdb", "identifier")
 }
 
-// InitNewTestDB creates a new test db pool and sets it to data.Pool
-// Call this if you're using data.Pool somewhere and want your test
+// ConnectToTestDB creates a new test db pool and sets it to data.pool
+// Call this if you're using data.pool somewhere inside a function and want your test
 // to use our test db.
-//
-// If you're trying to use this and
-func InitNewTestDB() (*sql.DB, error) {
+func ConnectToTestDB() (*sql.DB, error) {
 	db, err := NewTestDB()
 	if err != nil {
 		return db, err
 	}
 
-	Pool = db
+	pool = db
 	return db, nil
 }

--- a/data/models/models.go
+++ b/data/models/models.go
@@ -22,8 +22,8 @@ type Group struct {
 func GetGroup(db *sql.DB, slug string) (*Group, error) {
 	row := db.QueryRow(`
 		select slug, name, note, created_at, updated_at
-		from groups;
-	`)
+		from groups where slug = $1
+	`, slug)
 
 	var group Group
 	err := row.Scan(&group.Slug,
@@ -62,6 +62,41 @@ type Organization struct {
 	Note      string                  `json:"note"`
 	CreatedAt marshal.MarshalableTime `json:"created_at"`
 	UpdatedAt marshal.MarshalableTime `json:"updated_at"`
+}
+
+// GetOrganization gets an organization at any slug
+func GetOrganization(db *sql.DB, slug string) (*Organization, error) {
+	row := db.QueryRow(`
+		select slug, name, note, created_at, updated_at
+		from organizations where slug = $1
+	`, slug)
+
+	var org Organization
+	err := row.Scan(&org.Slug,
+		&org.Name, &org.Note, &org.CreatedAt, &org.UpdatedAt)
+
+	// This is not an error from the user's perspective
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &org, nil
+}
+
+// PutOrganization creates a group with this name and note
+func PutOrganization(db *sql.DB, name string, note string) (string, error) {
+	slug := slugify.MakeLang(name, "en")
+
+	query := `
+		INSERT INTO organizations (slug, name, note)
+		VALUES ($1, $2, $3)
+	`
+
+	_, err := db.Exec(query, slug, name, note)
+	return slug, err
 }
 
 // Podcast is a something with an audio link, a name, and a note

--- a/handlers/webfinger/README.md
+++ b/handlers/webfinger/README.md
@@ -1,0 +1,23 @@
+# What's Webfinger?
+
+[Webfinger](https://en.wikipedia.org/wiki/WebFinger), a protocol for discovering objects on the server. It's used by Mastodon and is important for interop'ing with Mastodon.
+
+It lives at a special route: `GET /.well-known/webfinger`.
+
+We can expect a webfinger response to always looks something like this:
+
+```json
+{
+  "subject": "acct:alice@my-example.com",
+
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/activity+json",
+      "href": "https://my-example.com/actor"
+    }
+  ]
+}
+```
+
+In this case, `alice` would be the Organization `slug` and `my-example.com` is the domain of the server.

--- a/handlers/webfinger/address.go
+++ b/handlers/webfinger/address.go
@@ -1,0 +1,65 @@
+/*
+An address is a wrapper around the Organization actor type.
+
+To interop with the rest of the world, Organization's are given identifiers that look like this: "planet-money@ex-host-server.org".
+
+Combined with webfinger, this is the outside world's way of finding a particular resource on our server.
+*/
+
+package webfinger
+
+import (
+	"errors"
+	"net/mail"
+	"strings"
+
+	"github.com/metapods/metapods/config"
+	"github.com/metapods/metapods/data"
+	"github.com/metapods/metapods/data/models"
+	"github.com/spf13/viper"
+)
+
+// slugOf gets the "slug" of an address; which is just the part to the left of the @.
+// So for `planet-money@foo.org`, the slug would be `planet-money`.
+func slugOf(address string) string {
+	fragments := strings.Split(address, "@")
+	return fragments[0]
+}
+
+func atAddress(address string) (*Actor, error) {
+
+	// Although these aren't technically email addresses,
+	// they still match a subset of the RFC 5322 email format
+	parser := mail.AddressParser{}
+	_, err := parser.Parse(address)
+	if err != nil {
+		return nil, errors.New("badly formatted address")
+	}
+
+	// 99pi@blah.org => 99pi
+	slug := slugOf(address)
+
+	// If you're thinking:
+	// > "Isn't this really inefficient to get the object
+	//   and then just return a reference so we can get it again?"
+	//
+	// You would be right.
+	_, err = models.GetOrganization(data.GetPool(), slug)
+	if err != nil {
+		return nil, err
+	}
+
+	domain := "https://" + viper.GetString(config.ServerHostname) +
+		":" + viper.GetString(config.ServerPort)
+
+	return &Actor{
+		Subject: address,
+		Links: []Link{
+			{
+				Rel:  "self",
+				Type: "application/activity+json",
+				HREF: domain + "/activity/organizations/" + slug,
+			},
+		},
+	}, nil
+}

--- a/handlers/webfinger/address.go
+++ b/handlers/webfinger/address.go
@@ -44,9 +44,12 @@ func atAddress(address string) (*Actor, error) {
 	//   and then just return a reference so we can get it again?"
 	//
 	// You would be right.
-	_, err = models.GetOrganization(data.GetPool(), slug)
+	org, err := models.GetOrganization(data.GetPool(), slug)
 	if err != nil {
 		return nil, err
+	}
+	if org == nil {
+		return nil, nil
 	}
 
 	domain := "https://" + viper.GetString(config.ServerHostname) +

--- a/handlers/webfinger/address.go
+++ b/handlers/webfinger/address.go
@@ -9,7 +9,6 @@ Combined with webfinger, this is the outside world's way of finding a particular
 package webfinger
 
 import (
-	"errors"
 	"net/mail"
 	"strings"
 
@@ -18,6 +17,18 @@ import (
 	"github.com/metapods/metapods/data/models"
 	"github.com/spf13/viper"
 )
+
+type badAddressError struct {
+	address string
+}
+
+func (e *badAddressError) Error() string {
+	return "badly formatted address: " + e.address
+}
+
+func newBadAddressError(address string) *badAddressError {
+	return &badAddressError{address: address}
+}
 
 // slugOf gets the "slug" of an address; which is just the part to the left of the @.
 // So for `planet-money@foo.org`, the slug would be `planet-money`.
@@ -33,7 +44,7 @@ func atAddress(address string) (*Actor, error) {
 	parser := mail.AddressParser{}
 	_, err := parser.Parse(address)
 	if err != nil {
-		return nil, errors.New("badly formatted address")
+		return nil, newBadAddressError(address)
 	}
 
 	// 99pi@blah.org => 99pi

--- a/handlers/webfinger/address_test.go
+++ b/handlers/webfinger/address_test.go
@@ -1,21 +1,28 @@
 package webfinger
 
 import (
+	"log"
 	"testing"
 
 	_ "github.com/lib/pq"
 
 	"github.com/metapods/metapods/data"
+	"github.com/metapods/metapods/data/models"
 	"github.com/stretchr/testify/assert"
 )
 
 // Runs before everything
 func init() {
 	data.SetupTestDB()
-	data.ConnectToTestDB()
 }
 
 func TestAtAddressCanFail(t *testing.T) {
+	db, err := data.ConnectToTestDB()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
 	var tests = []struct {
 		id     string
 		passes bool
@@ -45,4 +52,32 @@ func TestAtAddressCanFail(t *testing.T) {
 
 		assert.Equal(t, row.passes, err == nil, row.id+message)
 	}
+}
+
+func TestAtAddressReturnsNilIfNoAddress(t *testing.T) {
+	db, err := data.ConnectToTestDB()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	actor, err := atAddress("m@iscool.org")
+	assert.Nil(t, err)
+	assert.Nil(t, actor)
+}
+
+func TestAtAddressReturnsOrgReferenceIfExists(t *testing.T) {
+	db, err := data.ConnectToTestDB()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	slug, err := models.PutOrganization(db, "woo", "a note")
+	assert.Equal(t, "woo", slug) // Sanity check
+
+	actor, err := atAddress("woo@moo.org")
+	assert.Nil(t, err)
+	assert.NotNil(t, actor)
+	assert.Equal(t, "woo@moo.org", actor.Subject)
 }

--- a/handlers/webfinger/address_test.go
+++ b/handlers/webfinger/address_test.go
@@ -1,0 +1,48 @@
+package webfinger
+
+import (
+	"testing"
+
+	_ "github.com/lib/pq"
+
+	"github.com/metapods/metapods/data"
+	"github.com/stretchr/testify/assert"
+)
+
+// Runs before everything
+func init() {
+	data.SetupTestDB()
+	data.ConnectToTestDB()
+}
+
+func TestAtAddressCanFail(t *testing.T) {
+	var tests = []struct {
+		id     string
+		passes bool
+	}{
+		// Good data
+		{"joe@foodog.com", true},
+		{"foo@marco.polo.edu", true},
+		{"sf.county@marco.polo.org", true},
+		{"w@f.c", true},
+
+		// Bad data
+		{" ", false},
+		{"@", false},
+		{"m@", false},
+		{"not-an-address", false},
+	}
+
+	for _, row := range tests {
+		_, err := atAddress(row.id)
+
+		var message string
+		if row.passes {
+			message = " should have passed"
+		} else {
+			message = " should have failed"
+		}
+
+		assert.Equal(t, row.passes, err == nil, row.id+message)
+	}
+}

--- a/handlers/webfinger/objects.go
+++ b/handlers/webfinger/objects.go
@@ -1,0 +1,14 @@
+package webfinger
+
+// Link to another ActivityStreams object
+type Link struct {
+	Rel  string `json:"rel"`
+	Type string `json:"type"`
+	HREF string `json:"href"`
+}
+
+// Actor includes links to an ActivityStreams Actor object
+type Actor struct {
+	Subject string `json:"subject"`
+	Links   []Link `json:"links"`
+}

--- a/handlers/webfinger/objects_test.go
+++ b/handlers/webfinger/objects_test.go
@@ -1,0 +1,52 @@
+package webfinger
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Stolen from here:
+// https://stackoverflow.com/questions/32081808/strip-all-whitespace-from-a-string
+func removeWhitespace(str string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, str)
+}
+
+func TestLinkMarshalsCorrectly(t *testing.T) {
+	bytes, err := json.Marshal(Link{Rel: "rel", Type: "type", HREF: "href"})
+
+	assert.Nil(t, err)
+	assert.Equal(t, string(bytes), `{"rel":"rel","type":"type","href":"href"}`)
+}
+
+func TestActorMarshalsCorrectly(t *testing.T) {
+	expected := `{
+		"subject": "acct:alice@my-example.com",
+	
+		"links": [
+			{
+				"rel": "self",
+				"type": "application/activity+json",
+				"href": "https://my-example.com/actor"
+			}
+		]
+	}`
+
+	bytes, err := json.Marshal(Actor{
+		Subject: "acct:alice@my-example.com",
+		Links: []Link{
+			{Rel: "self", Type: "application/activity+json", HREF: "https://my-example.com/actor"},
+		},
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, removeWhitespace(string(bytes)), removeWhitespace(expected))
+}

--- a/handlers/webfinger/webfinger.go
+++ b/handlers/webfinger/webfinger.go
@@ -20,18 +20,53 @@ package webfinger
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"strings"
 )
+
+func getAddressFromResource(resource string) (string, error) {
+	fragments := strings.Split(resource, ":")
+	if fragments[0] != "acct" {
+		return "", errors.New("resource did not start with 'acct:'")
+	}
+
+	return fragments[1], nil
+}
 
 // Get returns a webfinger response
 func Get(w http.ResponseWriter, r *http.Request) {
-	str, err := json.Marshal(Actor{
-		Subject: "acct:bob@foo.dogs.com",
-		Links: []Link{
-			{Rel: "self", Type: "application/activity+json", HREF: "https://my-example.com/actor"},
-		},
-	})
 
+	// expect a request like ?resource=acct:joe@example.org
+	resource := r.URL.Query().Get("resource")
+	if resource == "" {
+		http.Error(w, "missing 'resource' query parameter in webfinger", http.StatusBadRequest)
+		return
+	}
+
+	// acct:foo@dogs.com => foo@dogs.com
+	address, err := getAddressFromResource(resource)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	actor, err := atAddress(address)
+	if err != nil {
+
+		// Poor formated errors are user errors (ie: 400)
+		if _, ok := err.(*badAddressError); ok {
+			http.Error(w, "incorrect address format", http.StatusBadRequest)
+			return
+		}
+
+		// other errors are just 500s
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
+	str, err := json.Marshal(actor)
+
+	// This _really_ should not happen.
 	if err != nil {
 		panic(err)
 	}

--- a/handlers/webfinger/webfinger.go
+++ b/handlers/webfinger/webfinger.go
@@ -18,9 +18,23 @@ and possibly other sites.
 
 package webfinger
 
-import "net/http"
+import (
+	"encoding/json"
+	"net/http"
+)
 
 // Get returns a webfinger response
 func Get(w http.ResponseWriter, r *http.Request) {
+	str, err := json.Marshal(Actor{
+		Subject: "acct:bob@foo.dogs.com",
+		Links: []Link{
+			{Rel: "self", Type: "application/activity+json", HREF: "https://my-example.com/actor"},
+		},
+	})
 
+	if err != nil {
+		panic(err)
+	}
+
+	w.Write(str)
 }

--- a/handlers/webfinger/webfinger.go
+++ b/handlers/webfinger/webfinger.go
@@ -18,8 +18,9 @@ and possibly other sites.
 
 package webfinger
 
-import "net/url"
+import "net/http"
 
-func Get(id *url.URL) {
+// Get returns a webfinger response
+func Get(w http.ResponseWriter, r *http.Request) {
 
 }

--- a/handlers/webfinger/webfinger.go
+++ b/handlers/webfinger/webfinger.go
@@ -62,6 +62,12 @@ func Get(w http.ResponseWriter, r *http.Request) {
 
 		// other errors are just 500s
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// 404s
+	if actor == nil {
+		http.Error(w, "no such account", http.StatusNotFound)
 	}
 
 	str, err := json.Marshal(actor)

--- a/handlers/webfinger/webfinger_test.go
+++ b/handlers/webfinger/webfinger_test.go
@@ -1,19 +1,44 @@
 package webfinger
 
 import (
+	"log"
+	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
+	"github.com/metapods/metapods/data"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWebfinger(t *testing.T) {
+func TestWebfingerBadRequests(t *testing.T) {
+	db, err := data.ConnectToTestDB()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
 
-	r := httptest.NewRequest("GET", "https://localhost:8080/.well-known/webfinger", nil)
-	w := httptest.NewRecorder()
+	var tests = []struct {
+		query string
+		code  int
+	}{
+		// 400s
+		{"?not-resource", http.StatusBadRequest},
+		{"?resource", http.StatusBadRequest},
+		{"?resource=::foomandoop@bloop", http.StatusBadRequest},
+		{"?resource=acct:not-an-address", http.StatusBadRequest},
 
-	Get(w, r)
+		// 404s
+		{"?resource=acct:joe@moo.org", http.StatusNotFound},
+	}
 
-	assert.Equal(t, w.Code, 200)
-	assert.NotEqual(t, w.Body.String(), "")
+	for _, test := range tests {
+		r := httptest.NewRequest("GET",
+			"https://localhost:8080/.well-known/webfinger"+test.query, nil)
+		w := httptest.NewRecorder()
+
+		Get(w, r)
+
+		assert.Equal(t, test.code, w.Code, test.query+" should have a status of "+strconv.Itoa(test.code))
+	}
 }

--- a/handlers/webfinger/webfinger_test.go
+++ b/handlers/webfinger/webfinger_test.go
@@ -1,0 +1,19 @@
+package webfinger
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebfinger(t *testing.T) {
+
+	r := httptest.NewRequest("GET", "https://localhost:8080/.well-known/webfinger", nil)
+	w := httptest.NewRecorder()
+
+	Get(w, r)
+
+	assert.Equal(t, w.Code, 200)
+	assert.NotEqual(t, w.Body.String(), "")
+}

--- a/lib/activity/activity.go
+++ b/lib/activity/activity.go
@@ -36,7 +36,7 @@ func Has(id *url.URL) (bool, error) {
 		return false, nil
 	}
 
-	group, err := models.GetGroup(data.Pool, getSlug(id))
+	group, err := models.GetGroup(data.GetPool(), getSlug(id))
 	if err != nil {
 		return false, err
 	}

--- a/lib/activity/activity.go
+++ b/lib/activity/activity.go
@@ -1,4 +1,4 @@
-package activitypub
+package activity
 
 import (
 	"fmt"

--- a/lib/activity/activity_test.go
+++ b/lib/activity/activity_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	data.RegisterTestDB()
+	data.SetupTestDB()
 }
 
 func TestOwnsCanConformToTheConfig(t *testing.T) {
@@ -74,7 +74,7 @@ func TestMatchesURLSpec(t *testing.T) {
 
 func TestHasFailsIfNothingExists(t *testing.T) {
 
-	db, err := data.InitNewTestDB()
+	db, err := data.ConnectToTestDB()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestHasFailsIfNothingExists(t *testing.T) {
 }
 
 func TestHasPassesIfSomethingExists(t *testing.T) {
-	db, err := data.InitNewTestDB()
+	db, err := data.ConnectToTestDB()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/lib/activity/activity_test.go
+++ b/lib/activity/activity_test.go
@@ -1,4 +1,4 @@
-package activitypub
+package activity
 
 import (
 	"log"

--- a/main.go
+++ b/main.go
@@ -4,9 +4,14 @@ import (
 	"io"
 	"log"
 	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/metapods/metapods/handlers/webfinger"
 )
 
 func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/.well-known/webfinger", webfinger.Get).Methods("GET")
 
 	http.HandleFunc("/health", healthHandler)
 	log.Fatal(http.ListenAndServe(":8080", nil))


### PR DESCRIPTION
# Overview

Adds [webfinger](https://en.wikipedia.org/wiki/WebFinger), a protocol for discovering objects on the server. It's used by Mastodon and is important for interop'ing with Mastodon. 

It lives at a special route: `GET /.well-known/webfinger`. 